### PR TITLE
Extract ProgrammingExercise styling and also apply to in-browser editor

### DIFF
--- a/data/osa-1/2-tulostaminen.md
+++ b/data/osa-1/2-tulostaminen.md
@@ -27,13 +27,13 @@ Esimerkiksi seuraava ohjelma tulostaa rivin _Moi kaikki_:
 print("Moi kaikki!")
 ```
 
-<in-browser-programming-exercise organization="test" course="python-test" exercise="osa01-01_hymio" title="Tehtävä: Hymiö">
+<in-browser-programming-exercise name="Hymiö" tmcname="osa01-01_hymio">
 
 Kirjoita ohjelma, joka tulostaa ruudulle hymiön: :-)
 
 </in-browser-programming-exercise>
 
-<in-browser-programming-exercise organization="test" course="python-test" exercise="osa01-02_ukko_nooa" title="Tehtävä: Ukko Nooa">
+<in-browser-programming-exercise name="Ukko Nooa" tmcname="osa01-02_ukko_nooa" >
 
 Kirjoita ohjelma, joka tulostaa ruudulle seuraavat rivit (tarkalleen annetussa muodossa välimerkkeineen):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17942,9 +17942,9 @@
       "integrity": "sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ=="
     },
     "moocfi-python-editor": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/moocfi-python-editor/-/moocfi-python-editor-0.6.1.tgz",
-      "integrity": "sha512-CukrldaN4Q746zNF2evS2d9gxoPSC95hSTwNfROX1AE5eZX/CNG5eAkA8AwgBucGbn7THPJKUdkg3us0enn4pw=="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/moocfi-python-editor/-/moocfi-python-editor-0.6.2.tgz",
+      "integrity": "sha512-oaPcfgCYy/pjdnMNsJRs95yfoUhGUPrOfkUen1e0nmW2gH3Gjxn8khb2aD36R8HF/FH79K8zaoz9/n3KtvIegg=="
     },
     "moocfi-quizzes": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "likert-react": "0.0.0-beta6",
     "moment": "^2.24.0",
     "monaco-editor": "^0.20.0",
-    "moocfi-python-editor": "^0.6.1",
+    "moocfi-python-editor": "^0.6.2",
     "moocfi-quizzes": "^0.4.4",
     "pdf-slideshow": "^0.1.4",
     "prismjs": "^1.19.0",

--- a/src/partials/ProgrammingExercise/ProgrammingExerciseCard.js
+++ b/src/partials/ProgrammingExercise/ProgrammingExerciseCard.js
@@ -1,0 +1,170 @@
+import React from "react"
+import styled from "styled-components"
+import ContentLoader from "react-content-loader"
+import { withTranslation } from "react-i18next"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faPencilAlt as icon, faRedo } from "@fortawesome/free-solid-svg-icons"
+import { Card, CardContent, Button } from "@material-ui/core"
+
+import { normalizeExerciseId } from "../../util/strings"
+import withSimpleErrorBoundary from "../../util/withSimpleErrorBoundary"
+
+const accentColor = "#FAAA38"
+
+const Body = styled.div`
+  padding-bottom: 0.5rem;
+  min-height: 300px;
+`
+
+const Header = styled.div`
+  font-size: 1.3rem;
+  font-weight: normal;
+  padding 1rem 0;
+  border-bottom: 1px solid #f7f7f9;
+  background-color: #D23D48;
+  display: flex;
+  flex-direction: row;
+  align-items: 0;
+  color: white;
+  padding: 1rem;
+  padding-bottom: 1.5rem;
+  h3 {
+    margin-bottom: 0;
+  }
+`
+
+const HeaderMuted = styled.span`
+  font-size: 18px;
+  font-weight: 400;
+  margin-right: 0.2rem;
+  position: relative;
+  bottom: -3px;
+`
+
+const HeaderTitleContainer = styled.div`
+  flex: 1;
+`
+
+const PointContentWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`
+
+const PointsLabel = styled.span`
+  font-size: 18px;
+  font-weight: 400;
+`
+
+const PointsWrapper = styled.div`
+  margin-left: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  text-align: right;
+  color: white;
+`
+
+const ProgrammingExerciseWrapper = styled(Card)`
+  margin: 3.5rem 0;
+  // border-left: 0.2rem solid ${accentColor};
+  border-radius: 1rem !important;
+  box-shadow: 0 8px 40px -12px rgba(0,0,0,0.3) !important;
+  padding: 0 !important;
+`
+
+const StyledIcon = styled(FontAwesomeIcon)`
+  vertical-align: middle;
+  margin-right: 1.5rem;
+  margin-left: 0.5rem;
+  color: white;
+  position: relative;
+  bottom: -13px;
+`
+
+const StyledQuizPointsContentLoader = styled(ContentLoader)`
+  width: 100%;
+  max-width: 30px;
+  height: 31.2px;
+  position: relative;
+  top: -4px;
+`
+
+const StyledRefreshIcon = styled(FontAwesomeIcon)`
+  color: white;
+`
+
+class ProgrammingExerciseCard extends React.Component {
+  render() {
+    const {
+      children,
+      name,
+      awardedPoints,
+      points,
+      onRefresh,
+      allowRefresh,
+    } = this.props
+
+    return (
+      <ProgrammingExerciseWrapper
+        id={normalizeExerciseId(`programming-exercise-${name}`)}
+      >
+        <Header>
+          <StyledIcon icon={icon} size="2x" />
+          <HeaderTitleContainer>
+            <HeaderMuted>{this.props.t("programmingExercise")} </HeaderMuted>
+            <h3>{name}</h3>
+          </HeaderTitleContainer>
+          {allowRefresh && (
+            <Button onClick={onRefresh}>
+              <StyledRefreshIcon icon={faRedo} />
+            </Button>
+          )}
+          <PointsWrapper>
+            <PointsLabel>{this.props.t("points")}</PointsLabel>
+            <PointContentWrapper>
+              {awardedPoints !== undefined ? (
+                <span>{awardedPoints}</span>
+              ) : (
+                <StyledQuizPointsContentLoader
+                  animate={!points}
+                  height={40}
+                  width={30}
+                  speed={2}
+                  primaryColor="#ffffff"
+                  primaryOpacity={0.6}
+                  secondaryColor="#dddddd"
+                  secondaryOpacity={0.6}
+                >
+                  <rect x="0" y="10" rx="12" ry="12" width="30" height="30" />
+                </StyledQuizPointsContentLoader>
+              )}
+              <span>/</span>
+              {points ? (
+                <span>{points}</span>
+              ) : (
+                <StyledQuizPointsContentLoader
+                  animate
+                  height={40}
+                  width={30}
+                  speed={2}
+                  primaryColor="#ffffff"
+                  primaryOpacity={0.6}
+                  secondaryColor="#dddddd"
+                  secondaryOpacity={0.6}
+                >
+                  <rect x="0" y="10" rx="12" ry="12" width="30" height="30" />
+                </StyledQuizPointsContentLoader>
+              )}
+            </PointContentWrapper>
+          </PointsWrapper>
+        </Header>
+        <CardContent>
+          <Body>{children}</Body>
+        </CardContent>
+      </ProgrammingExerciseWrapper>
+    )
+  }
+}
+
+export default withTranslation("common")(
+  withSimpleErrorBoundary(ProgrammingExerciseCard),
+)

--- a/src/partials/ProgrammingExercise/index.js
+++ b/src/partials/ProgrammingExercise/index.js
@@ -1,11 +1,7 @@
 import React from "react"
 import styled from "styled-components"
-import ContentLoader from "react-content-loader"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { faPencilAlt as icon, faRedo } from "@fortawesome/free-solid-svg-icons"
 import { OutboundLink } from "gatsby-plugin-google-analytics"
 import { get } from "lodash"
-import { Card, CardContent, Button } from "@material-ui/core"
 
 import { withTranslation } from "react-i18next"
 import {
@@ -15,77 +11,10 @@ import {
 import LoginStateContext from "../../contexes/LoginStateContext"
 import LoginControls from "../../components/LoginControls"
 import withSimpleErrorBoundary from "../../util/withSimpleErrorBoundary"
-import { normalizeExerciseId } from "../../util/strings"
 import ExerciseDescription from "./ExerciseDescription"
 import ExtraDetails from "./ExtraDetails"
 import StyledDivider from "../../components/StyledDivider"
-
-const accentColor = "#FAAA38"
-
-const ProgrammingExerciseWrapper = styled(Card)`
-  margin: 3.5rem 0;
-  // border-left: 0.2rem solid ${accentColor};
-  border-radius: 1rem !important;
-  box-shadow: 0 8px 40px -12px rgba(0,0,0,0.3) !important;
-  padding: 0 !important;
-`
-
-const StyledIcon = styled(FontAwesomeIcon)`
-  vertical-align: middle;
-  margin-right: 1.5rem;
-  margin-left: 0.5rem;
-  color: white;
-  position: relative;
-  bottom: -13px;
-`
-
-const StyledRefreshIcon = styled(FontAwesomeIcon)`
-  color: white;
-`
-
-const Header = styled.div`
-  font-size: 1.3rem;
-  font-weight: normal;
-  padding 1rem 0;
-  border-bottom: 1px solid #f7f7f9;
-  background-color: #D23D48;
-  display: flex;
-  flex-direction: row;
-  align-items: 0;
-  color: white;
-  padding: 1rem;
-  padding-bottom: 1.5rem;
-  h3 {
-    margin-bottom: 0;
-  }
-`
-
-const HeaderTitleContainer = styled.div`
-  flex: 1;
-`
-
-const HeaderMuted = styled.span`
-  font-size: 18px;
-  font-weight: 400;
-  margin-right: 0.2rem;
-  position: relative;
-  bottom: -3px;
-`
-
-const PointsLabel = styled.span`
-  font-size: 18px;
-  font-weight: 400;
-`
-
-const PointContentWrapper = styled.div`
-  display: flex;
-  justify-content: flex-end;
-`
-
-const Body = styled.div`
-  padding-bottom: 0.5rem;
-  min-height: 300px;
-`
+import ProgrammingExerciseCard from "./ProgrammingExerciseCard"
 
 const LoginNag = styled.div`
   margin-bottom: 1rem;
@@ -98,27 +27,11 @@ const LoginNagWrapper = styled.div`
   justify-content: center;
 `
 
-const PointsWrapper = styled.div`
-  margin-left: 0.5rem;
-  display: flex;
-  flex-direction: column;
-  text-align: right;
-  color: white;
-`
-
 const Small = styled.div`
   p {
     font-size: 0.9rem;
     color: #333;
   }
-`
-
-const StyledQuizPointsContentLoader = styled(ContentLoader)`
-  width: 100%;
-  max-width: 30px;
-  height: 31.2px;
-  position: relative;
-  top: -4px;
 `
 
 class ProgrammingExercise extends React.Component {
@@ -213,110 +126,47 @@ class ProgrammingExercise extends React.Component {
     )
 
     return (
-      <ProgrammingExerciseWrapper
-        id={normalizeExerciseId(`programming-exercise-${name}`)}
+      <ProgrammingExerciseCard
+        name={name}
+        points={points}
+        awardedPoints={awardedPoints}
+        onRefresh={this.onUpdate}
+        allowRefresh={this.context.loggedIn}
       >
-        <Header>
-          <StyledIcon icon={icon} size="2x" />
-          <HeaderTitleContainer>
-            <HeaderMuted>{this.props.t("programmingExercise")} </HeaderMuted>
-            <h3>{name}</h3>
-          </HeaderTitleContainer>
-
-          {this.context.loggedIn && (
-            <Button onClick={this.onUpdate}>
-              <StyledRefreshIcon icon={faRedo} />
-            </Button>
-          )}
-          <PointsWrapper>
-            <PointsLabel>{this.props.t("points")}</PointsLabel>
-
-            <PointContentWrapper>
-              {awardedPoints !== undefined ? (
-                <span>{awardedPoints}</span>
-              ) : (
-                <StyledQuizPointsContentLoader
-                  animate={!points}
-                  height={40}
-                  width={30}
-                  speed={2}
-                  primaryColor="#ffffff"
-                  primaryOpacity={0.6}
-                  secondaryColor="#dddddd"
-                  secondaryOpacity={0.6}
-                >
-                  <rect x="0" y="10" rx="12" ry="12" width="30" height="30" />
-                </StyledQuizPointsContentLoader>
-              )}
-              <span>/</span>
-              {points ? (
-                <span>{points}</span>
-              ) : (
-                <StyledQuizPointsContentLoader
-                  animate
-                  height={40}
-                  width={30}
-                  speed={2}
-                  primaryColor="#ffffff"
-                  primaryOpacity={0.6}
-                  secondaryColor="#dddddd"
-                  secondaryOpacity={0.6}
-                >
-                  <rect x="0" y="10" rx="12" ry="12" width="30" height="30" />
-                </StyledQuizPointsContentLoader>
-              )}
-            </PointContentWrapper>
-          </PointsWrapper>
-        </Header>
-        <CardContent>
-          <Body>
+        <div>
+          {this.context.loggedIn ? (
             <div>
-              {this.context.loggedIn ? (
-                <div>
-                  {points && points > 1 && (
-                    <Small>
-                      <p>
-                        {this.props.t("submitNB")}{" "}
-                        <OutboundLink
-                          href="https://www.mooc.fi/fi/installation/netbeans"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          {this.props.t("submitHowTo")}
-                        </OutboundLink>
-                        .
-                      </p>
-                      <StyledDivider />
-                    </Small>
-                  )}
-                  <ExerciseDescription>{children}</ExerciseDescription>
-                  {this.state.exerciseDetails === null && (
-                    <div>Error loading exercise details</div>
-                  )}
-                </div>
-              ) : (
-                <div>
-                  <LoginNag>{this.props.t("loginForExercise")}</LoginNag>
-                  <LoginNagWrapper>
-                    <LoginControls />
-                  </LoginNagWrapper>
-                </div>
+              {points && points > 1 && (
+                <Small>
+                  <p>
+                    {this.props.t("submitNB")}{" "}
+                    <OutboundLink
+                      href="https://www.mooc.fi/fi/installation/netbeans"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      {this.props.t("submitHowTo")}
+                    </OutboundLink>
+                    .
+                  </p>
+                  <StyledDivider />
+                </Small>
+              )}
+              <ExerciseDescription>{children}</ExerciseDescription>
+              {this.state.exerciseDetails === null && (
+                <div>Error loading exercise details</div>
               )}
             </div>
-
-            {this.context.loggedIn && (
-              <div>
-                <StyledDivider />
-                <ExtraDetails
-                  exerciseDetails={this.state.exerciseDetails}
-                  onUpdate={this.onUpdate}
-                  nocoins={this.props.nocoins}
-                />
-              </div>
-            )}
-          </Body>
-        </CardContent>
-      </ProgrammingExerciseWrapper>
+          ) : (
+            <div>
+              <LoginNag>{this.props.t("loginForExercise")}</LoginNag>
+              <LoginNagWrapper>
+                <LoginControls />
+              </LoginNagWrapper>
+            </div>
+          )}
+        </div>
+      </ProgrammingExerciseCard>
     )
   }
 }


### PR DESCRIPTION
Extracted styling from ProgrammingExercise to its own component. InBrowserProgrammingExercise now uses same styling.

Also changed in-browser-programming-exercise partial to use the same convention as the normal one. Organization and Course globals are hardcoded at the moment to use the test course. For the same reason obtained points can't be fetched at the moment.