### PR TITLE
Fix wrong variable name in material

### DIFF
--- a/data/osa-4/3-listat.md
+++ b/data/osa-4/3-listat.md
@@ -391,7 +391,7 @@ pituus = len(lista)
 
 print("Pienin:", pienin)
 print("Suurin:", suurin)
-print("Listan pituus:", summa)
+print("Listan pituus:", pituus)
 
 # funktiokutsu: lista on parametrina, järjestetty lista paluuarvona
 jarjestyksessa = sorted(lista)


### PR DESCRIPTION
In osa-4/3-listat.md the following example is given:
```
suurin = max(lista)
pienin = min(lista)
pituus = len(lista)

print("Pienin:", pienin)
print("Suurin:", suurin)
print("Listan pituus:", summa)
```

Here, the last print should use `pituus` instead of `summa` which is not defined.